### PR TITLE
Fixed support for little endian NBT data and unified Java and Bedrock file handling

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,9 +17,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        edition: [bedrock_edition, java_edition]
 
     steps:
     - uses: actions/checkout@v2
@@ -31,9 +28,4 @@ jobs:
         override: true
 
     - name: Run Tests
-      run: |
-        if [[ "${{ matrix.edition }}" == "bedrock_edition" ]]; then
-          cargo test --no-default-features --features ${{ matrix.edition }}
-        else
-          cargo test --features ${{ matrix.edition }}
-        fi
+      run: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,7 @@ keywords = ["minecraft", "nbt", "bedrock", "java", "data"]
 categories = ["data-structures", "parsing", "utilities"]
 
 [features]
-default = ["java_edition"]
 serde = []
-java_edition = []
-bedrock_edition = []
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "commandblock"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Jake 'PIXL' Evans", "Valink Solutions"]
 edition = "2021"
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -96,7 +96,6 @@ impl<R: Read> NbtReader<R> {
             }
             0x0B => {
                 let array_length = self.parse_int()? as usize;
-                let array_length = array_length as usize;
                 let mut array = Vec::with_capacity(array_length);
                 for _ in 0..array_length {
                     let value = self.parse_int()?;
@@ -113,7 +112,7 @@ impl<R: Read> NbtReader<R> {
                 }
                 Ok(NbtValue::LongArray(array))
             }
-            _ => return Err(NbtError::InvalidTagType(tag_type)),
+            _ => Err(NbtError::InvalidTagType(tag_type)),
         }
     }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,241 +1,256 @@
 use std::{collections::HashMap, fs::File, io::Read, path::PathBuf};
 
-use byteorder::ReadBytesExt;
+use byteorder::{BigEndian, LittleEndian, ReadBytesExt};
 
-#[cfg(feature = "java_edition")]
-use byteorder::BigEndian;
-
-#[cfg(feature = "bedrock_edition")]
-use byteorder::LittleEndian;
-
-use crate::types::{Compression, NbtError, NbtValue};
+use crate::{
+    types::{Compression, NbtError, NbtValue},
+    Endian,
+};
 
 use flate2::read::{GzDecoder, ZlibDecoder};
 
-pub fn parse_nbt_value<R: Read>(reader: &mut R, tag_type: u8) -> Result<NbtValue, NbtError> {
-    match tag_type {
-        0x00 => Ok(NbtValue::End),
-        0x01 => {
-            let value = parse_byte(reader)?;
-            Ok(NbtValue::Byte(value))
-        }
-        0x02 => {
-            let value = parse_short(reader)?;
-            Ok(NbtValue::Short(value))
-        }
-        0x03 => {
-            let value = parse_int(reader)?;
-            Ok(NbtValue::Int(value))
-        }
-        0x04 => {
-            let value = parse_long(reader)?;
-            Ok(NbtValue::Long(value))
-        }
-        0x05 => {
-            let value = parse_float(reader)?;
-            Ok(NbtValue::Float(value))
-        }
-        0x06 => {
-            let value = parse_double(reader)?;
-            Ok(NbtValue::Double(value))
-        }
-        0x07 => {
-            let array_length = parse_int(reader)? as usize;
-            let mut array = Vec::with_capacity(array_length);
+pub struct NbtReader<R: Read> {
+    reader: R,
+    endian: Endian,
+}
 
-            for _ in 0..array_length {
-                let value = parse_byte(reader)?;
-                array.push(value);
+impl<R: Read> NbtReader<R> {
+    pub fn new(reader: R, endian: Endian) -> Self {
+        NbtReader { reader, endian }
+    }
+
+    pub fn parse_nbt_value(&mut self, tag_type: u8) -> Result<NbtValue, NbtError> {
+        match tag_type {
+            0x00 => Ok(NbtValue::End),
+            0x01 => {
+                let value = self.parse_byte()?;
+                Ok(NbtValue::Byte(value))
             }
-            Ok(NbtValue::ByteArray(array))
-        }
-        0x08 => {
-            let value = parse_string(reader)?;
-            Ok(NbtValue::String(value))
-        }
-        0x09 => {
-            let initial_byte = parse_byte(reader)? as u8;
-            let list_tag_type = NbtValue::from_binary(initial_byte);
-            let array_length = parse_int(reader)?;
-
-            if list_tag_type.is_none() {
-                return Err(NbtError::InvalidTagType(initial_byte));
+            0x02 => {
+                let value = self.parse_short()?;
+                Ok(NbtValue::Short(value))
             }
+            0x03 => {
+                let value = self.parse_int()?;
+                Ok(NbtValue::Int(value))
+            }
+            0x04 => {
+                let value = self.parse_long()?;
+                Ok(NbtValue::Long(value))
+            }
+            0x05 => {
+                let value = self.parse_float()?;
+                Ok(NbtValue::Float(value))
+            }
+            0x06 => {
+                let value = self.parse_double()?;
+                Ok(NbtValue::Double(value))
+            }
+            0x07 => {
+                let value = self.parse_byte_array()?;
+                Ok(NbtValue::ByteArray(value))
+            }
+            0x08 => {
+                let value = self.parse_string()?;
+                Ok(NbtValue::String(value))
+            }
+            0x09 => {
+                let initial_byte = self.parse_byte()? as u8;
+                let list_tag_type = NbtValue::from_binary(initial_byte);
+                let array_length = self.parse_int()?;
 
-            let mut vec = Vec::with_capacity(array_length as usize);
-
-            for _ in 0..array_length {
-                if let Some(tag_type) = list_tag_type.as_ref() {
-                    let value = parse_nbt_value(reader, tag_type.to_binary())?;
-                    vec.push(value);
-                } else {
+                if list_tag_type.is_none() {
                     return Err(NbtError::InvalidTagType(initial_byte));
                 }
-            }
 
-            Ok(NbtValue::List(vec))
-        }
-        0x0A => {
-            let mut map = HashMap::new();
+                let mut vec = Vec::with_capacity(array_length as usize);
 
-            loop {
-                match parse_tag(reader) {
-                    Ok((key, value)) => {
-                        if let NbtValue::End = value {
-                            break;
-                        }
-                        map.insert(key, value);
+                for _ in 0..array_length {
+                    if let Some(tag_type) = list_tag_type.as_ref() {
+                        let value = self.parse_nbt_value(tag_type.to_binary())?;
+                        vec.push(value);
+                    } else {
+                        return Err(NbtError::InvalidTagType(initial_byte));
                     }
-                    Err(NbtError::InvalidCompoundType(0)) => break,
-                    Err(e) => return Err(e),
                 }
+
+                Ok(NbtValue::List(vec))
+            }
+            0x0A => {
+                let mut map = HashMap::new();
+
+                loop {
+                    match self.parse_nbt_tag() {
+                        Ok((key, value)) => {
+                            if let NbtValue::End = value {
+                                break;
+                            }
+                            map.insert(key, value);
+                        }
+                        Err(NbtError::InvalidCompoundType(0)) => break,
+                        Err(e) => return Err(e),
+                    }
+                }
+
+                Ok(NbtValue::Compound(map))
+            }
+            0x0B => {
+                let array_length = self.parse_int()? as usize;
+                let array_length = array_length as usize;
+                let mut array = Vec::with_capacity(array_length);
+                for _ in 0..array_length {
+                    let value = self.parse_int()?;
+                    array.push(value);
+                }
+                Ok(NbtValue::IntArray(array))
+            }
+            0x0C => {
+                let array_length = self.parse_int()? as usize;
+                let mut array = Vec::with_capacity(array_length);
+                for _ in 0..array_length {
+                    let value = self.parse_long()?;
+                    array.push(value);
+                }
+                Ok(NbtValue::LongArray(array))
+            }
+            _ => return Err(NbtError::InvalidTagType(tag_type)),
+        }
+    }
+
+    pub fn parse_data(&mut self) -> Result<(String, NbtValue), NbtError> {
+        let mut header = [0_u8; 1];
+        self.reader.read_exact(&mut header)?;
+
+        if let Some(tag) = NbtValue::from_binary(header[0]) {
+            if let NbtValue::End = tag {
+                return Ok((String::new(), NbtValue::End));
             }
 
-            Ok(NbtValue::Compound(map))
+            let name = self.parse_string()?;
+            let value = if self.endian == Endian::Little {
+                let mut header = [0_u8; 8];
+                self.reader.read_exact(&mut header)?;
+                let _ = i32::from_le_bytes(header[..4].try_into().unwrap());
+                let _ = i32::from_le_bytes(header[4..].try_into().unwrap());
+                // Parse the file_type and file_length if needed
+                self.parse_nbt_value(tag.to_binary())?
+            } else {
+                self.parse_nbt_value(tag.to_binary())?
+            };
+
+            Ok((name, value))
+        } else {
+            Err(NbtError::InvalidTagType(header[0]))
         }
-        0x0B => {
-            let array_length = parse_int(reader)? as usize;
-            let array_length = array_length as usize;
-            let mut array = Vec::with_capacity(array_length);
-            for _ in 0..array_length {
-                let value = parse_int(reader)?;
-                array.push(value);
+    }
+
+    fn parse_nbt_tag(&mut self) -> Result<(String, NbtValue), NbtError> {
+        let mut header = [0_u8; 1];
+        self.reader.read_exact(&mut header)?;
+
+        if let Some(tag) = NbtValue::from_binary(header[0]) {
+            if let NbtValue::End = tag {
+                return Ok((String::new(), NbtValue::End));
             }
-            Ok(NbtValue::IntArray(array))
+
+            let name = self.parse_string()?;
+            let value = self.parse_nbt_value(tag.to_binary())?;
+
+            Ok((name, value))
+        } else {
+            Err(NbtError::InvalidTagType(header[0]))
         }
-        0x0C => {
-            let array_length = parse_int(reader)? as usize;
-            let mut array = Vec::with_capacity(array_length);
-            for _ in 0..array_length {
-                let value = parse_long(reader)?;
-                array.push(value);
-            }
-            Ok(NbtValue::LongArray(array))
+    }
+
+    fn parse_double(&mut self) -> Result<f64, NbtError> {
+        let value = match self.endian {
+            Endian::Big => self.reader.read_f64::<BigEndian>()?,
+            Endian::Little => self.reader.read_f64::<LittleEndian>()?,
+        };
+        Ok(value)
+    }
+
+    fn parse_byte(&mut self) -> Result<i8, NbtError> {
+        let mut data = [0u8; 1];
+        self.reader.read_exact(&mut data)?;
+        Ok(data[0] as i8)
+    }
+
+    fn parse_short(&mut self) -> Result<i16, NbtError> {
+        let value = match self.endian {
+            Endian::Big => self.reader.read_i16::<BigEndian>()?,
+            Endian::Little => self.reader.read_i16::<LittleEndian>()?,
+        };
+        Ok(value)
+    }
+
+    fn parse_int(&mut self) -> Result<i32, NbtError> {
+        let value = match self.endian {
+            Endian::Big => self.reader.read_i32::<BigEndian>()?,
+            Endian::Little => self.reader.read_i32::<LittleEndian>()?,
+        };
+        Ok(value)
+    }
+
+    fn parse_long(&mut self) -> Result<i64, NbtError> {
+        let value = match self.endian {
+            Endian::Big => self.reader.read_i64::<BigEndian>()?,
+            Endian::Little => self.reader.read_i64::<LittleEndian>()?,
+        };
+        Ok(value)
+    }
+
+    fn parse_float(&mut self) -> Result<f32, NbtError> {
+        let value = match self.endian {
+            Endian::Big => self.reader.read_f32::<BigEndian>()?,
+            Endian::Little => self.reader.read_f32::<LittleEndian>()?,
+        };
+        Ok(value)
+    }
+
+    fn parse_string(&mut self) -> Result<String, NbtError> {
+        let string_length = self.parse_short()? as usize;
+        let mut string = String::with_capacity(string_length);
+        let mut buffer = vec![0u8; string_length];
+        self.reader.read_exact(&mut buffer)?;
+        string.push_str(&String::from_utf8_lossy(&buffer[..]));
+        Ok(string)
+    }
+
+    fn parse_byte_array(&mut self) -> Result<Vec<i8>, NbtError> {
+        let array_length = self.parse_int()? as usize;
+        let mut array = Vec::with_capacity(array_length);
+        for _ in 0..array_length {
+            let value = self.parse_byte()?;
+            array.push(value);
         }
-        _ => return Err(NbtError::InvalidTagType(tag_type)),
+        Ok(array)
     }
 }
 
-fn parse_tag<R: Read>(reader: &mut R) -> Result<(String, NbtValue), NbtError> {
-    let mut header = [0_u8; 1];
-    reader.read_exact(&mut header)?;
-
-    if let Some(tag) = NbtValue::from_binary(header[0]) {
-        if let NbtValue::End = tag {
-            return Ok((String::new(), NbtValue::End));
-        }
-
-        let name = parse_string(reader)?;
-        let value = parse_nbt_value(reader, tag.to_binary())?;
-
-        Ok((name, value))
-    } else {
-        Err(NbtError::InvalidTagType(header[0]))
-    }
-}
-
-fn parse_byte<R: Read>(reader: &mut R) -> Result<i8, NbtError> {
-    let mut data = [0u8; 1];
-    reader.read_exact(&mut data)?;
-    Ok(data[0] as i8)
-}
-
-fn parse_short<R: Read>(reader: &mut R) -> Result<i16, NbtError> {
-    #[cfg(feature = "java_edition")]
-    {
-        let value = reader.read_i16::<BigEndian>()?;
-        Ok(value)
-    }
-
-    #[cfg(feature = "bedrock_edition")]
-    {
-        let value = reader.read_i16::<LittleEndian>()?;
-        Ok(value)
-    }
-}
-
-fn parse_int<R: Read>(reader: &mut R) -> Result<i32, NbtError> {
-    #[cfg(feature = "java_edition")]
-    {
-        let value = reader.read_i32::<BigEndian>()?;
-        Ok(value)
-    }
-
-    #[cfg(feature = "bedrock_edition")]
-    {
-        let value = reader.read_i32::<LittleEndian>()?;
-        Ok(value)
-    }
-}
-
-fn parse_long<R: Read>(reader: &mut R) -> Result<i64, NbtError> {
-    #[cfg(feature = "java_edition")]
-    {
-        let value = reader.read_i64::<BigEndian>()?;
-        Ok(value)
-    }
-
-    #[cfg(feature = "bedrock_edition")]
-    {
-        let value = reader.read_i64::<LittleEndian>()?;
-        Ok(value)
-    }
-}
-
-fn parse_float<R: Read>(reader: &mut R) -> Result<f32, NbtError> {
-    #[cfg(feature = "java_edition")]
-    {
-        let value = reader.read_f32::<BigEndian>()?;
-        Ok(value)
-    }
-
-    #[cfg(feature = "bedrock_edition")]
-    {
-        let value = reader.read_f32::<LittleEndian>()?;
-        Ok(value)
-    }
-}
-
-fn parse_double<R: Read>(reader: &mut R) -> Result<f64, NbtError> {
-    #[cfg(feature = "java_edition")]
-    {
-        let value = reader.read_f64::<BigEndian>()?;
-        Ok(value)
-    }
-
-    #[cfg(feature = "bedrock_edition")]
-    {
-        let value = reader.read_f64::<LittleEndian>()?;
-        Ok(value)
-    }
-}
-
-fn parse_string<R: Read>(reader: &mut R) -> Result<String, NbtError> {
-    let string_length = parse_short(reader)? as usize;
-    let mut string = String::with_capacity(string_length);
-    let mut buffer = vec![0u8; string_length];
-    reader.read_exact(&mut buffer)?;
-    string.push_str(&String::from_utf8_lossy(&buffer[..]));
-    Ok(string)
-}
-
-pub fn read_from_file(path: PathBuf, compression: Compression) -> Result<NbtValue, NbtError> {
+pub fn read_from_file(
+    path: PathBuf,
+    compression: Compression,
+    endian_style: Endian,
+) -> Result<NbtValue, NbtError> {
     let mut file = File::open(path)?;
 
     match compression {
         Compression::Uncompressed => {
-            // handle parsing data and consumed bytes
-            let (_, value) = parse_tag(&mut file)?;
+            let mut parser = NbtReader::new(file, endian_style);
+            let (_, value) = parser.parse_data()?;
             Ok(value)
         }
         Compression::Gzip => {
             let mut decoder = GzDecoder::new(&mut file);
-            let (_, value) = parse_tag(&mut decoder)?;
+            let mut parser = NbtReader::new(&mut decoder, endian_style);
+            let (_, value) = parser.parse_data()?;
             Ok(value)
         }
         Compression::Zlib => {
             let mut decoder = ZlibDecoder::new(&mut file);
-            let (_, value) = parse_tag(&mut decoder)?;
+            let mut parser = NbtReader::new(&mut decoder, endian_style);
+            let (_, value) = parser.parse_data()?;
             Ok(value)
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -81,3 +81,9 @@ impl From<std::io::Error> for NbtError {
         NbtError::IoError(e)
     }
 }
+
+#[derive(Debug, PartialEq)]
+pub enum Endian {
+    Big,
+    Little,
+}

--- a/tests/reader_test.rs
+++ b/tests/reader_test.rs
@@ -1,51 +1,210 @@
-use std::io::Cursor;
 use std::path::PathBuf;
 
-use commandblock::{parse_nbt_value, read_from_file, Compression, NbtValue};
+use commandblock::{read_from_file, Compression, NbtReader, NbtValue};
 
 #[test]
 fn test_parse_nbt_value_end() {
     let data = [0x00];
-    let result = parse_nbt_value(&mut Cursor::new(&data[..]), 0x00).unwrap();
+    let result = NbtReader::new(&data[..], commandblock::Endian::Big)
+        .parse_nbt_value(0x00)
+        .unwrap();
     assert_eq!(result, NbtValue::End);
 }
 
 #[test]
 fn test_parse_nbt_value_byte() {
     let data = [0x7F];
-    let result = parse_nbt_value(&mut Cursor::new(&data[..]), 0x01).unwrap();
+    let result = NbtReader::new(&data[..], commandblock::Endian::Big)
+        .parse_nbt_value(0x01)
+        .unwrap();
     assert_eq!(result, NbtValue::Byte(127));
 }
 
 #[test]
 fn test_parse_nbt_value_short() {
-    #[cfg(feature = "bedrock_edition")]
-    let data = [0xFF, 0x7F];
+    let java_data = [0x7F, 0xFF];
+    let java_result = NbtReader::new(&java_data[..], commandblock::Endian::Big)
+        .parse_nbt_value(0x02)
+        .unwrap();
 
-    #[cfg(feature = "java_edition")]
-    let data = [0x7F, 0xFF];
+    let bedrock_data = [0xFF, 0x7F];
+    let bedrock_result = NbtReader::new(&bedrock_data[..], commandblock::Endian::Little)
+        .parse_nbt_value(0x02)
+        .unwrap();
 
-    let result = parse_nbt_value(&mut Cursor::new(&data[..]), 0x02).unwrap();
-    assert_eq!(result, NbtValue::Short(32767));
+    assert_eq!(java_result, NbtValue::Short(32767));
+    assert_eq!(bedrock_result, NbtValue::Short(32767));
+}
+
+#[test]
+fn test_parse_nbt_value_int() {
+    let java_data = [0x7F, 0xFF, 0xFF, 0xFF];
+    let java_result = NbtReader::new(&java_data[..], commandblock::Endian::Big)
+        .parse_nbt_value(0x03)
+        .unwrap();
+
+    let bedrock_data = [0xFF, 0xFF, 0xFF, 0x7F];
+    let bedrock_result = NbtReader::new(&bedrock_data[..], commandblock::Endian::Little)
+        .parse_nbt_value(0x03)
+        .unwrap();
+
+    assert_eq!(java_result, NbtValue::Int(2147483647));
+    assert_eq!(bedrock_result, NbtValue::Int(2147483647));
+}
+
+#[test]
+fn test_parse_nbt_value_long() {
+    let java_data = [0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF];
+    let java_result = NbtReader::new(&java_data[..], commandblock::Endian::Big)
+        .parse_nbt_value(0x04)
+        .unwrap();
+
+    let bedrock_data = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F];
+    let bedrock_result = NbtReader::new(&bedrock_data[..], commandblock::Endian::Little)
+        .parse_nbt_value(0x04)
+        .unwrap();
+
+    assert_eq!(java_result, NbtValue::Long(9223372036854775807));
+    assert_eq!(bedrock_result, NbtValue::Long(9223372036854775807));
+}
+
+#[test]
+fn test_parse_nbt_value_float() {
+    let java_data = [0x7F, 0x7F, 0xFF, 0xFF];
+    let java_result = NbtReader::new(&java_data[..], commandblock::Endian::Big)
+        .parse_nbt_value(0x05)
+        .unwrap();
+
+    let bedrock_data = [0xFF, 0xFF, 0x7F, 0x7F];
+    let bedrock_result = NbtReader::new(&bedrock_data[..], commandblock::Endian::Little)
+        .parse_nbt_value(0x05)
+        .unwrap();
+
+    assert_eq!(java_result, NbtValue::Float(3.4028235e38));
+    assert_eq!(bedrock_result, NbtValue::Float(3.4028235e38));
+}
+
+#[test]
+fn test_parse_nbt_value_double() {
+    let java_data = [0x7F, 0xEF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF];
+    let java_result = NbtReader::new(&java_data[..], commandblock::Endian::Big)
+        .parse_nbt_value(0x06)
+        .unwrap();
+
+    let bedrock_data = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xEF, 0x7F];
+    let bedrock_result = NbtReader::new(&bedrock_data[..], commandblock::Endian::Little)
+        .parse_nbt_value(0x06)
+        .unwrap();
+
+    assert_eq!(java_result, NbtValue::Double(1.7976931348623157e308));
+    assert_eq!(bedrock_result, NbtValue::Double(1.7976931348623157e308));
+}
+
+#[test]
+fn test_parse_nbt_value_byte_array() {
+    let java_data = [
+        0x00, 0x00, 0x00, 0x02, // array length
+        0x7F, 0x7F, // array values
+    ];
+    let java_result = NbtReader::new(&java_data[..], commandblock::Endian::Big)
+        .parse_nbt_value(0x07)
+        .unwrap();
+
+    let bedrock_data = [
+        0x02, 0x00, 0x00, 0x00, // array length
+        0x7F, 0x7F, // array values
+    ];
+    let bedrock_result = NbtReader::new(&bedrock_data[..], commandblock::Endian::Little)
+        .parse_nbt_value(0x07)
+        .unwrap();
+
+    assert_eq!(java_result, NbtValue::ByteArray(vec![127, 127]));
+    assert_eq!(bedrock_result, NbtValue::ByteArray(vec![127, 127]));
+}
+
+#[test]
+fn test_parse_nbt_value_string() {
+    let java_data = [
+        0x00, 0x02, // string length
+        0x41, 0x42, // string value
+    ];
+    let java_result = NbtReader::new(&java_data[..], commandblock::Endian::Big)
+        .parse_nbt_value(0x08)
+        .unwrap();
+
+    let bedrock_data = [
+        0x02, 0x00, // string length
+        0x41, 0x42, // string value
+    ];
+    let bedrock_result = NbtReader::new(&bedrock_data[..], commandblock::Endian::Little)
+        .parse_nbt_value(0x08)
+        .unwrap();
+
+    assert_eq!(java_result, NbtValue::String("AB".to_string()));
+    assert_eq!(bedrock_result, NbtValue::String("AB".to_string()));
+}
+
+#[test]
+fn test_parse_nbt_value_list() {
+    let java_data = [
+        0x01, // list tag type
+        0x00, 0x00, 0x00, 0x02, // array length
+        0x7F, 0x7F, // array values
+    ];
+    let java_result = NbtReader::new(&java_data[..], commandblock::Endian::Big)
+        .parse_nbt_value(0x09)
+        .unwrap();
+
+    let bedrock_data = [
+        0x01, // list tag type
+        0x02, 0x00, 0x00, 0x00, // array length
+        0x7F, 0x7F, // array values
+    ];
+    let bedrock_result = NbtReader::new(&bedrock_data[..], commandblock::Endian::Little)
+        .parse_nbt_value(0x09)
+        .unwrap();
+
+    assert_eq!(
+        java_result,
+        NbtValue::List(vec![NbtValue::Byte(127), NbtValue::Byte(127)])
+    );
+    assert_eq!(
+        bedrock_result,
+        NbtValue::List(vec![NbtValue::Byte(127), NbtValue::Byte(127)])
+    );
 }
 
 #[test]
 fn test_read_from_dat_file() {
-    #[cfg(feature = "bedrock_edition")]
-    let path = PathBuf::from("tests").join("data").join("bedrock_level.dat");
+    let java_data_path = PathBuf::from("tests").join("data").join("java_level.dat");
+    let bedrock_data_path = PathBuf::from("tests")
+        .join("data")
+        .join("bedrock_level.dat");
 
-    #[cfg(feature = "bedrock_edition")]
-    let result = read_from_file(path, Compression::Uncompressed);
+    let java_result = read_from_file(java_data_path, Compression::Gzip, commandblock::Endian::Big);
 
-    #[cfg(feature = "java_edition")]
-    let path = PathBuf::from("tests").join("data").join("java_level.dat");
+    let bedrock_result = read_from_file(
+        bedrock_data_path,
+        Compression::Uncompressed,
+        commandblock::Endian::Little,
+    );
 
-    #[cfg(feature = "java_edition")]
-    let result = read_from_file(path, Compression::Gzip);
-
-    match result {
+    match java_result {
         Ok(NbtValue::Compound(value)) => {
-            println!("{:?}", value);
+            println!("Java Data: {:?} \n", value);
+            assert!(true)
+        }
+        Ok(value) => {
+            assert!(false, "Expected NbtValue::Compound, but got {:?}", value);
+        }
+        Err(error) => {
+            assert!(false, "Failed to read NBT data from file: {:?}", error);
+        }
+    }
+
+    match bedrock_result {
+        Ok(NbtValue::Compound(value)) => {
+            println!("Bedrock Data: {:?} \n", value);
             assert!(true)
         }
         Ok(value) => {

--- a/tests/reader_test.rs
+++ b/tests/reader_test.rs
@@ -147,7 +147,7 @@ fn test_parse_nbt_value_string() {
 #[test]
 fn test_parse_nbt_value_list() {
     let java_data = [
-        0x01, // list tag type
+        0x01, // lists tag type
         0x00, 0x00, 0x00, 0x02, // array length
         0x7F, 0x7F, // array values
     ];
@@ -156,7 +156,7 @@ fn test_parse_nbt_value_list() {
         .unwrap();
 
     let bedrock_data = [
-        0x01, // list tag type
+        0x01, // lists tag type
         0x02, 0x00, 0x00, 0x00, // array length
         0x7F, 0x7F, // array values
     ];
@@ -172,6 +172,89 @@ fn test_parse_nbt_value_list() {
         bedrock_result,
         NbtValue::List(vec![NbtValue::Byte(127), NbtValue::Byte(127)])
     );
+}
+
+#[test]
+fn test_parse_nbt_value_compound() {
+    let java_data = [
+        0x01, // tag type
+        0x00, 0x02, // key length
+        0x41, 0x42, // key value
+        0x7F, // value
+        0x00, // end tag
+    ];
+    let java_result = NbtReader::new(&java_data[..], commandblock::Endian::Big)
+        .parse_nbt_value(0x0A)
+        .unwrap();
+
+    let bedrock_data = [
+        0x01, // tag type
+        0x02, 0x00, // key length
+        0x41, 0x42, // key value
+        0x7F, // value
+        0x00, // end tag
+    ];
+    let bedrock_result = NbtReader::new(&bedrock_data[..], commandblock::Endian::Little)
+        .parse_nbt_value(0x0A)
+        .unwrap();
+
+    let mut map = std::collections::HashMap::new();
+    map.insert("AB".to_string(), NbtValue::Byte(127));
+
+    assert_eq!(java_result, NbtValue::Compound(map));
+
+    let mut map = std::collections::HashMap::new();
+    map.insert("AB".to_string(), NbtValue::Byte(127));
+
+    assert_eq!(bedrock_result, NbtValue::Compound(map));
+}
+
+#[test]
+fn test_parse_nbt_value_int_array() {
+    let java_data = [
+        0x00, 0x00, 0x00, 0x02, // array length
+        0x00, 0x00, 0x00, 0x01, // array values
+        0x00, 0x00, 0x00, 0x02, // array values
+    ];
+    let java_result = NbtReader::new(&java_data[..], commandblock::Endian::Big)
+        .parse_nbt_value(0x0B)
+        .unwrap();
+
+    let bedrock_data = [
+        0x02, 0x00, 0x00, 0x00, // array length
+        0x01, 0x00, 0x00, 0x00, // array values
+        0x02, 0x00, 0x00, 0x00, // array values
+    ];
+    let bedrock_result = NbtReader::new(&bedrock_data[..], commandblock::Endian::Little)
+        .parse_nbt_value(0x0B)
+        .unwrap();
+
+    assert_eq!(java_result, NbtValue::IntArray(vec![1, 2]));
+    assert_eq!(bedrock_result, NbtValue::IntArray(vec![1, 2]));
+}
+
+#[test]
+fn test_parse_nbt_value_long_array() {
+    let java_data = [
+        0x00, 0x00, 0x00, 0x02, // array length
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // array values
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+    ];
+    let java_result = NbtReader::new(&java_data[..], commandblock::Endian::Big)
+        .parse_nbt_value(0x0C)
+        .unwrap();
+
+    let bedrock_data = [
+        0x02, 0x00, 0x00, 0x00, // array length
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // array values
+        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ];
+    let bedrock_result = NbtReader::new(&bedrock_data[..], commandblock::Endian::Little)
+        .parse_nbt_value(0x0C)
+        .unwrap();
+
+    assert_eq!(java_result, NbtValue::LongArray(vec![0, 1]));
+    assert_eq!(bedrock_result, NbtValue::LongArray(vec![0, 1]));
 }
 
 #[test]


### PR DESCRIPTION
This pull request addresses issue #1 by adding support for parsing little endian NBT data. When little endian is selected, the parsing process includes grabbing the file type and length (see [bedrock level.dat information](https://minecraft.fandom.com/wiki/Bedrock_Edition_level_format#level.dat)) at the beginning of the file. Currently, these values are ignored with ‘_’, but in the future, we can return these types upon request. At the moment, I don’t deem it necessary for my personal use cases.

Instead of using feature flags to handle Java and Bedrock style files separately, I opted to create a single base library that can handle both. This approach eliminates the need for implementing multiple APIs for NBT data parsing, which would be cumbersome.

Note that in an upcoming pull request, I plan to restructure the file naming and sorting mechanism to accommodate future expansion of the project beyond just NBT data parsing.