### PR TITLE
Added snbt and serde serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "commandblock"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Jake 'PIXL' Evans", "Valink Solutions"]
 edition = "2021"
 
@@ -13,10 +13,11 @@ keywords = ["minecraft", "nbt", "bedrock", "java", "data"]
 categories = ["data-structures", "parsing", "utilities"]
 
 [features]
-serde = []
+serde = ["dep:serde"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 byteorder = "1.4.3"
 flate2 = "1.0.26"
+serde = { version = "1.0.183", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,15 @@ keywords = ["minecraft", "nbt", "bedrock", "java", "data"]
 categories = ["data-structures", "parsing", "utilities"]
 
 [features]
-serde = ["dep:serde"]
+serde = ["serde"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 byteorder = "1.4.3"
 flate2 = "1.0.26"
-serde = { version = "1.0.183", features = ["derive"], optional = true }
+serde = { version = "1.0", optional = true }
+
+[dev-dependencies]
+flate2 = "1.0.26"
+serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["minecraft", "nbt", "bedrock", "java", "data"]
 categories = ["data-structures", "parsing", "utilities"]
 
 [features]
-serde = ["serde"]
+serde = ["dep:serde"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,21 @@ The primary aim of CommandBlock is to provide a versatile Rust-based solution fo
 
 ## Features (Planned)
 
-- NBT Data Handling: Parse, manipulate, and serialize Minecraft NBT data structures.
-- Anvil Data Parsing: Read and interpret Anvil world data format used in Minecraft.
-- Region File Support: Work with Minecraft region files efficiently.
-- Utility Functions: Provide convenient functions for common Minecraft data operations.
+- NBT Data Handling
+    - [x] Parse NBT data structures
+    - [x] NBT to Serde compatible structures
+    - [ ] Manipulate NBT data structures
+    - [ ] Write NBT data structures
+- Anvil Data Handling
+    - [ ] Parse Anvil data structures
+    - [ ] Interpret Anvil data structures
+    - [ ] Manipulate Anvil data structures
+    - [ ] Write Anvil data structures
+- Region File Support
+    - [ ] Read Minecraft region files
+    - [ ] Interpret Minecraft region files
+    - [ ] Manipulate Minecraft region files
+    - [ ] Write Minecraft region files
 
 ## Usage
 

--- a/src/nbt/types.rs
+++ b/src/nbt/types.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
-    fmt::{Debug, Display},
+    error::Error,
+    fmt::{Debug, Display, Formatter},
 };
 
 #[cfg(feature = "serde")]
@@ -159,6 +160,46 @@ pub enum NbtError {
 impl From<std::io::Error> for NbtError {
     fn from(e: std::io::Error) -> NbtError {
         NbtError::IoError(e)
+    }
+}
+
+impl Display for NbtError {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match *self {
+            NbtError::IoError(ref err) => write!(f, "IO error: {}", err),
+            NbtError::InvalidTagType(ref tag) => write!(f, "Invalid tag type: {}", tag),
+            NbtError::InvalidCompression(ref compression) => {
+                write!(f, "Invalid compression type: {}", compression)
+            }
+            NbtError::InvalidString(ref err) => write!(f, "Invalid string: {}", err),
+            NbtError::InvalidListType(ref tag) => write!(f, "Invalid list type: {}", tag),
+            NbtError::InvalidCompoundType(ref tag) => write!(f, "Invalid compound type: {}", tag),
+            NbtError::InvalidByteArrayLength(ref len) => {
+                write!(f, "Invalid byte array length: {}", len)
+            }
+            NbtError::InvalidIntArrayLength(ref len) => {
+                write!(f, "Invalid int array length: {}", len)
+            }
+            NbtError::InvalidLongArrayLength(ref len) => {
+                write!(f, "Invalid long array length: {}", len)
+            }
+        }
+    }
+}
+
+impl Error for NbtError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match *self {
+            NbtError::IoError(ref err) => Some(err),
+            NbtError::InvalidTagType(_) => None,
+            NbtError::InvalidCompression(_) => None,
+            NbtError::InvalidString(ref err) => Some(err),
+            NbtError::InvalidListType(_) => None,
+            NbtError::InvalidCompoundType(_) => None,
+            NbtError::InvalidByteArrayLength(_) => None,
+            NbtError::InvalidIntArrayLength(_) => None,
+            NbtError::InvalidLongArrayLength(_) => None,
+        }
     }
 }
 


### PR DESCRIPTION
now when reading NBT data you can serialize that `NbtValue` into a serde compatible struct when you have the serde feature flag enabled.

now by default we provide a .to_snbt() function that returns a SNBT formatted String.

also added a beater features list to show what is available in the library and what is planned.